### PR TITLE
updating the test command in javascript/package.json to match the typ…

### DIFF
--- a/javascript/package.json
+++ b/javascript/package.json
@@ -6,7 +6,7 @@
     "build": "webpack",
     "clean": "rimraf ./dist",
     "lint": "eslint \"src/**/*.js\"",
-    "testjs": "mocha --recursive --throw-deprecation --compilers js:babel-core/register --require babel-polyfill \"src/**/*.test.js\""
+    "test": "mocha --recursive --throw-deprecation --compilers js:babel-core/register --require babel-polyfill \"src/**/*.test.js\""
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
…escript/package.json

This addresses PR #4 .  The documentation said to use the test command to run the tests; however, in javascript projects this command was testjs.  This PR makes both the javascript project and the typescript project both use test to match the documentation.